### PR TITLE
fix: use ${GITHUB_ACTION_PATH} when referencing external files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
 
         case ${{ inputs.transformation }} in
           'gtest-to-generic-execution')
-            { echo '<testExecutions version="1">'; xsltproc converters/gtest-to-generic-execution.xslt ${{ inputs.input }}; echo '</testExecutions>'; } | tee ${{ inputs.output }} > /dev/null
+            { echo '<testExecutions version="1">'; xsltproc ${{ github.action_path }}/converters/gtest-to-generic-execution.xslt ${{ inputs.input }}; echo '</testExecutions>'; } | tee ${{ inputs.output }} > /dev/null
             ;;
           'mutation-test-to-generic-issue')
             ;;

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
 
         case ${{ inputs.transformation }} in
           'gtest-to-generic-execution')
-            { echo '<testExecutions version="1">'; xsltproc ${{ github.action_path }}/converters/gtest-to-generic-execution.xslt ${{ inputs.input }}; echo '</testExecutions>'; } | tee ${{ inputs.output }} > /dev/null
+            { echo '<testExecutions version="1">'; xsltproc ${GITHUB_ACTION_PATH}/converters/gtest-to-generic-execution.xslt ${{ inputs.input }}; echo '</testExecutions>'; } | tee ${{ inputs.output }} > /dev/null
             ;;
           'mutation-test-to-generic-issue')
             ;;


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

<!-- Fill in a description of what this PR changes/introduces/fixes
     Link to GitHub issues using keywords https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests when necessary
-->

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/sonarqube-issue-conversion/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
