### PR TITLE
chore: remove pip workaround

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
         python-version: "3.13"
 
     - shell: bash
-      run: pip install lxml
+      run: python -m pip install lxml
 
     - shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,7 @@ runs:
         python-version: "3.12"
 
     - shell: bash
-      run: |
-        python -m pip install --upgrade pip==24.3.1
-        pip install lxml
+      run: pip install lxml
 
     - shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
-        python-version: "3.12"
+        python-version: "3.13"
 
     - shell: bash
       run: pip install lxml


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This PR removes the workaround to install a specific pip version because of path issues. And simultaneously updates Python to 3.13.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/sonarqube-issue-conversion/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
